### PR TITLE
Connect id changer

### DIFF
--- a/client/public/relatedItems/style.css
+++ b/client/public/relatedItems/style.css
@@ -180,7 +180,7 @@ button.set-text-name {
   font-weight: bold;
 }
 
-.comparison-modal-header .comparison-modal-close-button {
+.comparison-modal-header .close-button {
   cursor: pointer;
   border: none;
   outline: none;

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -25,7 +25,7 @@ class App extends Component {
       <>
       <Overview product_id={this.state.product_id}/>
       <RelatedItems
-        setOverviewId={this.changeId}
+        changeOverviewId={this.changeId}
         product_id={this.state.product_id}/>
       <Questions product_id={this.state.product_id}/>
       <Reviews product_id={this.state.product_id}/>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -26,7 +26,7 @@ class App extends Component {
       <Overview product_id={this.state.product_id}/>
       <RelatedItems
         changeOverviewId={this.changeId}
-        product_id={this.state.product_id}/>
+        overviewId={this.state.product_id}/>
       <Questions product_id={this.state.product_id}/>
       <Reviews product_id={this.state.product_id}/>
       </>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -25,8 +25,8 @@ class App extends Component {
       <>
       <Overview product_id={this.state.product_id}/>
       <RelatedItems
-        changeOverviewId={this.changeId}
-        overviewId={this.state.product_id}/>
+        changeId={this.changeId}
+        productId={this.state.product_id}/>
       <Questions product_id={this.state.product_id}/>
       <Reviews product_id={this.state.product_id}/>
       </>

--- a/client/src/components/relatedItems/Cards.jsx
+++ b/client/src/components/relatedItems/Cards.jsx
@@ -94,7 +94,7 @@ class Cards extends Component {
 
                 :
 
-                <button alt="This is an overlay where you click to delete this item from your saved outfits." className="overlay" onClick={() => { this.props.deleteYourOutfits(this.props.id) }}></button>}
+                <button className="overlay" onClick={() => { this.props.deleteYourOutfits(this.props.id) }}></button>}
 
 
             </div>
@@ -106,7 +106,7 @@ class Cards extends Component {
                 {this.state.category}
               </div>
 
-              <button alt="This is a part of the text that displays the name of the item.  Click here to view this items details above." onClick={() => {this.props.setOverviewId(this.props.id)}} className="set-text-name">{this.state.name}</button>
+              <button onClick={() => {this.props.setOverviewId(this.props.id)}} className="set-text-name">{this.state.name}</button>
 
               {this.state.salePrice === null ?
                 <div className="text-price">

--- a/client/src/components/relatedItems/ComparisonModal.jsx
+++ b/client/src/components/relatedItems/ComparisonModal.jsx
@@ -27,7 +27,7 @@ class ComparisonModal extends Component {
 
     closeModalButtons.forEach(button => {
       button.addEventListener('click', () => {
-        const modal = button.closest('.comparison-modal')
+        const modal = document.querySelector(button.dataset.modalClose);
         this.closeModal(modal);
       })
     })
@@ -63,13 +63,13 @@ class ComparisonModal extends Component {
       <>
         <div className="parent-modal" ref={this.parentModal}>
 
-          <button alt="This is an overlay that helps to show the product comparison display." data-modal-target={this.uniqueSearch} className="overlay" ref={this.overlay}></button>
+          <button alt="display-product-comparison" data-modal-target={this.uniqueSearch} className="overlay" ref={this.overlay}></button>
 
           <div className="comparison-modal" id={this.uniqueId}>
 
             <div className="comparison-modal-header">
               <div className="comparison-modal-title">COMPARING</div>
-              <button alt="This is an overlay that helps to hide the product comparison display." data-modal-close id={this.props.id} className="comparison-modal-close-button" ref={this.buttonClose}>&times;</button>
+              <button alt="remove-product-comparison" data-modal-close={this.uniqueSearch} id={this.props.id} className="close-button" ref={this.buttonClose}>&times;</button>
             </div>
 
             <div className="comparison-modal-header">

--- a/client/src/components/relatedItems/RelatedItemsWidget.jsx
+++ b/client/src/components/relatedItems/RelatedItemsWidget.jsx
@@ -8,7 +8,7 @@ class RelatedItemsWidget extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      overviewId: 64626,
+      overviewId: 64620,
       overviewIdName: '',
       overviewIdFeatures: [],
       relatedProductsIds: []
@@ -21,16 +21,18 @@ class RelatedItemsWidget extends Component {
   // this.props.setOverviewId(id)
 
   componentDidMount() {
-    this.setOverviewId(this.state.overviewId);
-    console.log(this.props.product_id);
-    console.log(this.props.changeOverviewId);
+    this.setOverviewIdData();
   }
 
   setOverviewId(id) {
+    let idString = id.toString();
+    this.props.changeId(idString);
+
     this.setState({
       overviewId: id,
       relatedProductsIds: []
     })
+
     this.setOverviewIdData();
   }
 
@@ -97,8 +99,8 @@ class RelatedItemsWidget extends Component {
 import PropTypes from 'prop-types';
 
 RelatedItemsWidget.propTypes = {
-  product_id: PropTypes.string,
-  changeOverviewId: PropTypes.func
+  productId: PropTypes.string,
+  changeId: PropTypes.func
 }
 
 

--- a/client/src/components/relatedItems/RelatedItemsWidget.jsx
+++ b/client/src/components/relatedItems/RelatedItemsWidget.jsx
@@ -22,7 +22,8 @@ class RelatedItemsWidget extends Component {
 
   setOverviewId(id) {
     this.setState({
-      overviewId: id
+      overviewId: id,
+      relatedProductsIds: []
     })
     this.setOverviewIdData();
   }

--- a/client/src/components/relatedItems/RelatedItemsWidget.jsx
+++ b/client/src/components/relatedItems/RelatedItemsWidget.jsx
@@ -20,6 +20,12 @@ class RelatedItemsWidget extends Component {
   // this.props.product_id: '',
   // this.props.setOverviewId(id)
 
+  componentDidMount() {
+    this.setOverviewId(this.state.overviewId);
+    console.log(this.props.product_id);
+    console.log(this.props.changeOverviewId);
+  }
+
   setOverviewId(id) {
     this.setState({
       overviewId: id,
@@ -74,10 +80,6 @@ class RelatedItemsWidget extends Component {
 
   }
 
-  componentDidMount() {
-    this.setOverviewId(this.state.overviewId);
-  }
-
   render() {
 
     return (
@@ -91,5 +93,13 @@ class RelatedItemsWidget extends Component {
     )
   }
 }
+
+import PropTypes from 'prop-types';
+
+RelatedItemsWidget.propTypes = {
+  product_id: PropTypes.string,
+  changeOverviewId: PropTypes.func
+}
+
 
 export default RelatedItemsWidget;


### PR DESCRIPTION
Item clicks in Related Products Widget now re-assigns that item's id as the new product_id in the App.jsx component.

Please note, @DarianAltF4  I did not observe the Overview re-render accordingly... will require some minor code changes in Overview widget in order to re-render Overview upon product_id change... let me know if you have any questions.